### PR TITLE
Fix directory cleanup on build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "rm -rf ../public/{js,css,img} && vue-cli-service build --no-clean",
+    "build": "rm -rf ../public/js ../public/css ../public/img ../public/precache-manifest.*.js ../resources/views/index.blade.php && vue-cli-service build --no-clean",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {


### PR DESCRIPTION
- The `rm` command accepts multiple arguments, and most terminal emulators don't support multiple matching between curly brackets.
- The `index.blade.php` file must be regenerated each time the app builds, this ensures that we are not trying to use old code on the PWA.